### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,27 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'index.js'
+      - 'docs/**'
+      - 'package.json'
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: package
+        template: docs/template.md

--- a/docs/template.md
+++ b/docs/template.md
@@ -18,36 +18,6 @@
 
 [![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/aws-es-client?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/aws-es-client/?mode=list&logo=LGTM)
 
-:point_right: **Badges here** :point_left:
-
-****
-
-# Testing
-
-`mocha`, `chai`, `nyc`, `dotenv` & `standard` are available as dev dependencies.
-
-A `build` workflow (see [here](./.github/workflows/build.yml)) is running on `pull request` and will execute your test suite before allowing you to merge your PR. It also has a `coverage` job already prepared that you can comment out as soon as your testing is in place and your `REPORTER_ID` is in the repository secrets. This is the ID on _Code Climate_ used for uploading code coverage reports.
-
-****
-
-# Documentation
-
-This repository comes with a `generate-docs` workflow that generates documentation automatically for you using [`JSDOC`](https://jsdoc.app/). It'll check all your `.js` file for `JSDOC`-like comments in order to build its documentation. See [here](https://github.com/kaskadi/action-generate-docs) for more information.
-
-If you would like to see the workflow configuration, head [here](./.github/workflows/generate-docs.yml).
-
-You can configure the template used to generate the action documentation [here](./docs/template.md).
-
-****
-
-# Publishing
-
-Publishing to NPM is done automatically via a `publish` workflow (see [here](./.github/workflows/publish.yml)). This workflow will run on `push` to `master`. It checks the current published version versus the one in `package.json` and if `package.json` version is different then it publishes to NPM.
-
-**Warning: in order for this workflow to work properly, you'll have to manually publish your package on initial publish.**
-
 ****
 
 {{>main}}
-
-:point_down: **Your documentation here** :point_down:

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,53 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/aws-es-client)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/aws-es-client?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/aws-es-client/publish?label=publish&logo=npm)](https://github.com/kaskadi/aws-es-client/actions?query=workflow%3Apublish)
+[![](https://img.shields.io/github/workflow/status/kaskadi/aws-es-client/build?label=build&logo=mocha)](https://github.com/kaskadi/aws-es-client/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/aws-es-client/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/aws-es-client/actions?query=workflow%3Agenerate-docs)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/aws-es-client?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/aws-es-client)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/aws-es-client?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/aws-es-client)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/aws-es-client?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/aws-es-client)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/aws-es-client?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/aws-es-client/?mode=list&logo=LGTM)
+
+:point_right: **Badges here** :point_left:
+
+****
+
+# Testing
+
+`mocha`, `chai`, `nyc`, `dotenv` & `standard` are available as dev dependencies.
+
+A `build` workflow (see [here](./.github/workflows/build.yml)) is running on `pull request` and will execute your test suite before allowing you to merge your PR. It also has a `coverage` job already prepared that you can comment out as soon as your testing is in place and your `REPORTER_ID` is in the repository secrets. This is the ID on _Code Climate_ used for uploading code coverage reports.
+
+****
+
+# Documentation
+
+This repository comes with a `generate-docs` workflow that generates documentation automatically for you using [`JSDOC`](https://jsdoc.app/). It'll check all your `.js` file for `JSDOC`-like comments in order to build its documentation. See [here](https://github.com/kaskadi/action-generate-docs) for more information.
+
+If you would like to see the workflow configuration, head [here](./.github/workflows/generate-docs.yml).
+
+You can configure the template used to generate the action documentation [here](./docs/template.md).
+
+****
+
+# Publishing
+
+Publishing to NPM is done automatically via a `publish` workflow (see [here](./.github/workflows/publish.yml)). This workflow will run on `push` to `master`. It checks the current published version versus the one in `package.json` and if `package.json` version is different then it publishes to NPM.
+
+**Warning: in order for this workflow to work properly, you'll have to manually publish your package on initial publish.**
+
+****
+
+{{>main}}
+
+:point_down: **Your documentation here** :point_down:

--- a/index.js
+++ b/index.js
@@ -2,8 +2,39 @@ const { createAWSConnection, awsCredsifyAll } = require('@acuris/aws-es-connecti
 const { Client } = require('@elastic/elasticsearch')
 const AWS = require('aws-sdk')
 
-module.exports = function createClient (opt) {
-  var options = {...{region: 'eu-central-1'}, ...opt}
+/**
+ * @module aws-es-client
+ * @typicalname ES
+ */
+
+/**
+ * Options for the new ElasticSearch client instanciation
+ * @typedef {Object} Options
+ * @property {string} [region='eu-central-1'] - The region in which your ElasticSearch cluster lives
+ * @property {string} url - The URL of your ElasticSearch cluster on AWS
+ * @property {string} id - The ID of a programmatic user having access to ElasticSearch service on AWS
+ * @property {string} token - The token of a programmatic user having access to ElasticSearch service on AWS
+ */
+
+/**
+ * Creates a new client connected to your AWS ElasticSearch cluster. 
+ * 
+ * Once the client has been instanciated, you can use all the methods available in the regular ElasticSearch Node client (see [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html) for details)
+ * @function
+ * @param {Options} opts - {@link Options} to be passed to instanciate a new client
+ * @return {ES} New ElasticSearch client
+ *
+ * @example
+ *
+ * const ES = require('aws-es-client')({
+ *  url: process.env.ES_CLUSTER_URL,
+ *  id: process.env.ES_ID,
+ *  token: process.env.ES_SECRET
+ * })
+ */
+
+module.exports = function createClient (opts) {
+  const options = {...{region: 'eu-central-1'}, ...opts}
   AWS.config.update({
     credentials: new AWS.Credentials(options.id, options.token),
     region: options.region


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action

**New features**
- _`generate-docs` workflow:_ generates docs automatically based on a template in `docs/template.md` and using the action `action-generate-docs`.

**Updated features**
- _package entry point:_ added JSDoc comments for automated documentation generation